### PR TITLE
Fixes to make it work

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,11 +265,20 @@ install it with this command:
     $ brew install scala
 
 On Linux (specifically Ubuntu), it's a little more complicated. Here's what works for me:
-
-    $ echo "deb http://dl.bintray.com/sbt/debian /" | sudo tee -a /etc/apt/sources.list.d/sbt.list
-    $ sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 642AC823
+    
+    #Installing Java
     $ sudo apt-get update
-    $ sudo apt-get install openjdk-8-jdk scala sbt
+    $ sudo apt-get install openjdk-8-jdk scala 
+
+    #Installing sbt
+    $ sudo apt-get update
+    $ sudo apt-get install apt-transport-https curl gnupg -yqq
+    $ echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" | sudo tee /etc/apt/sources.list.d/sbt.list
+    $ echo "deb https://repo.scala-sbt.org/scalasbt/debian /" | sudo tee /etc/apt/sources.list.d/sbt_old.list
+    $ curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | sudo -H gpg --no-default-keyring --keyring gnupg-ring:/etc/apt/trusted.gpg.d/scalasbt-release.gpg --import
+    $ sudo chmod 644 /etc/apt/trusted.gpg.d/scalasbt-release.gpg
+    $ sudo apt-get update
+    $ sudo apt-get install sbt
 
 To build the executable, run
 

--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ install it with this command:
 
 On Linux (specifically Ubuntu), it's a little more complicated. Here's what works for me:
     
-    #Installing Java
+    #Installing Java, Scala
     $ sudo apt-get update
     $ sudo apt-get install openjdk-8-jdk scala 
 

--- a/bin/eventsim
+++ b/bin/eventsim
@@ -1,2 +1,2 @@
 #! /bin/bash
-$JAVA_HOME/bin/java -XX:+AggressiveOpts -XX:+UseG1GC -XX:+UseStringDeduplication -Xmx8G -jar target/scala-2.10/eventsim-assembly-1.0.jar $*
+$JAVA_HOME/bin/java -XX:+AggressiveOpts -XX:+UseG1GC -XX:+UseStringDeduplication -Xmx8G -jar target/scala-2.11/eventsim-assembly-1.0.jar $*

--- a/build.sbt
+++ b/build.sbt
@@ -2,6 +2,8 @@ name := "eventsim"
 
 version := "1.0"
 
+scalaVersion := "2.11.12"
+
 libraryDependencies += "org.apache.commons" % "commons-math3" % "3.5"
 
 libraryDependencies += "de.jollyday" % "jollyday" % "0.5.1"
@@ -13,3 +15,5 @@ libraryDependencies += "com.fasterxml.jackson.core" % "jackson-core" % "2.6.1"
 libraryDependencies += "com.fasterxml.jackson.core" % "jackson-databind" % "2.6.1"
 
 libraryDependencies += "org.apache.kafka" % "kafka_2.10" % "0.8.2.1"
+
+libraryDependencies += "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.2"

--- a/project/assembly.sbt
+++ b/project/assembly.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.13.0")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.1.0")


### PR DESCRIPTION
- Changed the `scalaVersion` to `2.11.12`
- Added `libraryDependencies += "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.2"` as a dependency
- Changed sbt-assembly version to `1.1.0`
- Improved installation steps for Scala, Java, sbt